### PR TITLE
Force unregistering witness before stopping the node

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,20 +2,22 @@
 
 This is a collection of bash scripts to automate the Hive-Engine Witness node snapshots backups.
 
-## `he_ss.sh`
+## `he_ss.sh` v1.0
 Name of the executable bash script that runs from anywhere you deploy.
 
 ## Configurables
 Inside the provided scripts are some variables allowing you to customise or adapt to your node infrastructure.
 
-### 1. `backup_mongodb.sh`
+### 1. `backup_mongodb.sh` v1.1
   - `PM2_PROCESS_NAME` - The name of your pm2 Hive-Engine node process. __(mandatory)__
   - `BACKUPS_DIR` - The backup directory to host your local snapshots (defaults to your home directory)
-### 2. `upload_archive_gdrive.sh`
+  - `WITNESS_NODE_DIR` - The directory where your Hive-Engine node runs from. (defaults to ~/prod/steemsmartcontracts) __(mandatory)__
+### 2. `upload_archive_gdrive.sh` v1.0
   - `PM2_PROCESS_NAME` - The name of your pm2 Hive-Engine node process. __(mandatory)__
   - `BACKUPS_DIR` - The backup directory to host your local snapshots (defaults to your home directory)
   - `GD_MOUNT` - The Google Drive local mountpoint (defaults to your home directory plus myGoogleDrive subdirectory)
   - `GD_SUBDIR` - The remote directory on your Google Drive to host your snapshots (defaults to hive-engine-snapshots)
+### 3. `test_commands.sh` v1.1 - (no configurables)
 
 ## How to start
 Change the variable `PM2_PROCESS_NAME` inside the `backup_mongodb.sh` and the `upload_archive_gdrive.sh` scripts to the name of your pm2 process. Then simply execute the script:
@@ -52,6 +54,7 @@ Otherwise you might need to add further paths to the PATH variable in order for 
 
 # Features
  - MongoDB node managed dumps (snapshots)
+ - Manages witness unregistration (to avoid missing blocks)
  - Uploading of snapshots backups to Google Drive with both remote and local rotation (in terms of number of backups)
  - Control of the transfer speeds:
    1. Local disk read speed of the upload...

--- a/backup_mongodb.sh
+++ b/backup_mongodb.sh
@@ -2,12 +2,13 @@
 # Program: Local HIVE-Engine Snapshots Backups (for HE-SS)
 # Description: Manages local snapshots backups for your HIVE-Engine witness node via MongoDB dumps and controls your node pm2 process state
 # Author: forykw
-# Date: 2021/04/02
-# v1.0
+# Date: 2021/04/03
+# v1.1
 
 ## Adjust to your node
 PM2_PROCESS_NAME="prod-hivengwit"
 BACKUPS_DIR="${HOME}"
+WITNESS_NODE_DIR="${HOME}/prod/steemsmartcontracts"
 
 # Timestamp format for script output
 timestamp_format ()
@@ -28,6 +29,11 @@ if [ ! -d ${BACKUPS_DIR} ]; then
 fi
 
 echo $(timestamp_format)"Starting local backup process.."
+echo $(timestamp_format)"Unregistering witness..."
+cd ${WITNESS_NODE_DIR}
+node witness_action.js unregister
+echo $(timestamp_format)"Message broadcasted! Waiting 5 seconds..."
+sleep 5
 echo $(timestamp_format)"Stopping node..."
 pm2 stop ${PM2_PROCESS_NAME}
 echo $(timestamp_format)"Dumping mongoDB..."

--- a/test_commands.sh
+++ b/test_commands.sh
@@ -2,8 +2,8 @@
 # Program: Crontab Command Test Helper (for HE-SS)
 # Description: Validates all required commands can sucessfully execute from crontab before enabling the script for production
 # Author: forykw
-# Date: 2021/04/02
-# v1.0
+# Date: 2021/04/03
+# v1.1
 
 # This script needs to run from crontab to test the commands run sucessfully, by evaluating its output
 `which echo` "### Start of test_commands.sh script"
@@ -24,4 +24,7 @@ printf "printf works\n"
 rsync --version > /dev/null && echo "rsync works"
 mountpoint --version > /dev/null && echo "mountpoint works"
 google-drive-ocamlfuse -version | head -n 1
+cd . && echo "cd works"
+echo "node version: "`node -v`
+sleep --version > /dev/null && echo "sleep works"
 echo "### End of test_commands.sh script (carefully inspect output above)"


### PR DESCRIPTION
This is a mandatory fix to forcibly unregister the witness first before stopping the node. On the (now) top20 nodes produce quite fast and the granularity of the he-awm script might not be quick enough. Later extra support will be provided to the monitor script (he-awm).